### PR TITLE
chore: update podspec

### DIFF
--- a/RudderAmplitude.podspec
+++ b/RudderAmplitude.podspec
@@ -11,7 +11,6 @@ Pod::Spec.new do |s|
     s.source           = { :git => 'https://github.com/rudderlabs/rudder-integration-amplitude-swift.git' , :tag => "v#{s.version}"}
     
     s.ios.deployment_target = '13.0'
-    s.osx.deployment_target   = '10.14'
     s.tvos.deployment_target  = '12.1'
     s.watchos.deployment_target = '7.0'
 


### PR DESCRIPTION
# Description

- update `RudderAmplitude.podspec` file by removing support for macOSX . Including macOSX support for SDK giving pod validation error while manual deployment on git (expecting libarclite_macosx.a file in Xcode location which is present at expected location in xcode)

The following error occurs when we execute: ` pod lib lint --no-clean --allow-warnings`
<img width="777" alt="image" src="https://github.com/user-attachments/assets/fe3f860e-f8fd-41d2-97b0-2e59a1331ab0">
<img width="435" alt="image" src="https://github.com/user-attachments/assets/41953209-63fd-4b25-b758-e9dc9a03aa79">

